### PR TITLE
fix: remove back arrow on add/edit connector drawer - EXO-71754

### DIFF
--- a/webapp/src/main/webapp/vue-app/external-visio/components/ExternalVisioDrawer.vue
+++ b/webapp/src/main/webapp/vue-app/external-visio/components/ExternalVisioDrawer.vue
@@ -25,13 +25,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       @closed="close">
       <template slot="title">
         <div class="d-flex">
-          <v-icon
-            size="16"
-            class="clickable"
-            :aria-label="$t('externalVisio.close.label')"
-            @click="close()">
-            fas fa-arrow-left
-          </v-icon>
           <span> {{ title }} </span>
         </div>
       </template>


### PR DESCRIPTION
The back arrow is not wanted in the add/edit external visio connector drawer.

This commit removes it