### PR TITLE
fix: Improve Add a visioconference link with external video conference - EXO-70996 (#36)

### DIFF
--- a/webapp/src/main/webapp/js/webconferencing-externalvisio.js
+++ b/webapp/src/main/webapp/js/webconferencing-externalvisio.js
@@ -56,6 +56,12 @@
       this.groupSupported = true;
 
       /**
+       * With External Visio, we allow to modify event url
+       */
+      this.canModifyEventUrl = true;
+
+
+      /**
        * MUST return a call type name. If several types supported, this one is
        * assumed as major one and it will be used for referring this connector
        * in getProvider() and similar methods. This type also should listed in


### PR DESCRIPTION
Before this fix, when the provider allow to modify the url of the visio, the url cannot be changed This commit add the possibility to update the visio url