### PR TITLE
fix : Correct display for external connectors button - EXO-85837

### DIFF
--- a/webapp/src/main/webapp/vue-app/CallButton/components/VisioConnectorMeetButton.vue
+++ b/webapp/src/main/webapp/vue-app/CallButton/components/VisioConnectorMeetButton.vue
@@ -1,7 +1,7 @@
 
 
 <template>
-  <div>
+  <div class="d-flex align-center full-width">
     <v-tooltip
       bottom
       :disabled="!displayTooltip">
@@ -23,7 +23,7 @@
       <span v-if="displayTooltip">{{ $t('externalVisio.label.btn.StartCall') }}</span>
     </v-tooltip>
     <span
-      class="text-truncate text-break text-wrap pt-2"
+      class="text-truncate text-break text-wrap"
       v-if="displayConnectorName"
       @click.stop.prevent="startCall">{{ nameConnector }}</span>
     <span


### PR DESCRIPTION
Before this fix, when the call button name is too long the display do not adapt in width This commit add flex display on the div containing the connector name